### PR TITLE
Update issue automation for design

### DIFF
--- a/.github/workflows/triage-move-labelled.yml
+++ b/.github/workflows/triage-move-labelled.yml
@@ -34,7 +34,13 @@ jobs:
     name: X-Needs-Design to Design project board
     runs-on: ubuntu-latest
     if: >
-        contains(github.event.issue.labels.*.name, 'X-Needs-Design')
+      contains(github.event.issue.labels.*.name, 'X-Needs-Design') &&
+      (contains(github.event.issue.labels.*.name, 'S-Critical') &&
+       (contains(github.event.issue.labels.*.name, 'O-Frequent') ||
+        contains(github.event.issue.labels.*.name, 'O-Occasional')) ||
+       contains(github.event.issue.labels.*.name, 'S-Major') &&
+       contains(github.event.issue.labels.*.name, 'O-Frequent') ||
+       contains(github.event.issue.labels.*.name, 'A11y'))
     steps:
       - uses: octokit/graphql-action@v2.x
         id: add_to_project


### PR DESCRIPTION
Put only high priority issues in front of the design team, all of which the design team will aim to action to keep the queue at zero