### PR TITLE
Add desktop link to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Element meta
 
-This is the home of shared Element app documentation and artefacts for the element [web, desktop](https://github.com/vector-im/element-web), [Android](https://github.com/vector-im/element-android) and [iOS](https://github.com/vector-im/element-ios) apps.
+This is the home of shared Element app documentation and artefacts for the element [web](https://github.com/vector-im/element-web), [desktop](https://github.com/element-hq/element-desktop), [Android](https://github.com/vector-im/element-android) and [iOS](https://github.com/vector-im/element-ios) apps.
 
 Each project will link to the [wiki](https://github.com/vector-im/element-meta/wiki) directly to reference processes that it has adopted.
 


### PR DESCRIPTION
It was surprising to me that the web and desktop version shared the same link, so I split them into 2 links and added the URL of the desktop repo. Is this correct?